### PR TITLE
set country code as a collection of string, fix failing tests

### DIFF
--- a/src/World.Net.UnitTests/Countries/AlandIslandsTest.cs
+++ b/src/World.Net.UnitTests/Countries/AlandIslandsTest.cs
@@ -9,7 +9,7 @@ public sealed class AlandIslandsTest
     private const int ALAND_ISLANDS_NUMERIC_CODE = 248;
     private const string ALAND_ISLANDS_ISO2_CODE = "AX";
     private const string ALAND_ISLANDS_ISO3_CODE = "ALA";
-    private const string ALAND_ISLANDS_CALLING_CODE = "+358";
+    private readonly string[] ALAND_ISLANDS_CALLING_CODE = ["+358"];
 
     [Fact]
     public void GetCountry_ReturnsCorrectInformation_ForAlandIslands()

--- a/src/World.Net.UnitTests/Countries/AlbaniaTests.cs
+++ b/src/World.Net.UnitTests/Countries/AlbaniaTests.cs
@@ -10,7 +10,7 @@ public sealed class AlbaniaTests
     private const int ALBANIA_NUMERIC_CODE = 008;
     private const string ALBANIA_ISO2_CODE = "AL";
     private const string ALBANIA_ISO3_CODE = "ALB";
-    private const string ALBANIA_CALLING_CODE = "+355";
+    private readonly string[] ALBANIA_CALLING_CODE = ["+355"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/AlgeriaTest.cs
+++ b/src/World.Net.UnitTests/Countries/AlgeriaTest.cs
@@ -9,7 +9,7 @@ public sealed class AlgeriaTest
     private const int ALGERIA_NUMERIC_CODE = 012;
     private const string ALGERIA_ISO2_CODE = "DZ";
     private const string ALGERIA_ISO3_CODE = "DZA";
-    private const string ALGERIA_CALLING_CODE = "+213";
+    private readonly string[] ALGERIA_CALLING_CODE = ["+213"];
     private const int ALGERIA_PROVINCE_COUNT = 57;
     private const string ALGERIA_STATE_TYPE = "Province";
     

--- a/src/World.Net.UnitTests/Countries/AmericanSamoaTest.cs
+++ b/src/World.Net.UnitTests/Countries/AmericanSamoaTest.cs
@@ -9,7 +9,7 @@ public sealed class AmericanSamoaTest
     private const int AmericanSamoa_NUMERIC_CODE = 016;
     private const string AmericanSamoa_ISO2_CODE = "AS";
     private const string AmericanSamoa_ISO3_CODE = "ASM";
-    private const string AmericanSamoa_CALLING_CODE = "+1";
+    private readonly string[] AmericanSamoa_CALLING_CODE = ["+1"];
     private const int AmericanSamoa_STATE_COUNT = 0;
     
     [Fact]

--- a/src/World.Net.UnitTests/Countries/AndorraTest.cs
+++ b/src/World.Net.UnitTests/Countries/AndorraTest.cs
@@ -9,7 +9,7 @@ public sealed class AndorraTest
     private const int ANDORRA_NUMERIC_CODE = 020;
     private const string ANDORRA_ISO2_CODE = "AD";
     private const string ANDORRA_ISO3_CODE = "AND";
-    private const string ANDORRA_CALLING_CODE = "+376";
+    private readonly string[] ANDORRA_CALLING_CODE = ["+376"];
     private const int ANDORRA_PARISH_COUNT = 7;
     private const string ANDORRA_STATE_TYPE = "Parish";
     

--- a/src/World.Net.UnitTests/Countries/AngolaTest.cs
+++ b/src/World.Net.UnitTests/Countries/AngolaTest.cs
@@ -9,7 +9,7 @@ public sealed class AngolaTest
     private const string ANGOLA_ISO2_CODE = "AO";
     private const string ANGOLA_ISO3_CODE = "AGO";
     private const int ANGOLA_NUMERIC_CODE = 024;
-    private const string ANGOLA_CALLING_CODE = "+244";
+    private readonly string[] ANGOLA_CALLING_CODE = ["+244"];
     private const string ANGOLA_STATE_TYPE = "Province";
 
 

--- a/src/World.Net.UnitTests/Countries/AnguillaTest.cs
+++ b/src/World.Net.UnitTests/Countries/AnguillaTest.cs
@@ -9,7 +9,7 @@ public sealed class AnguillaTest
     private const string ANGUILLA_ISO2_CODE = "AI";
     private const string ANGUILLA_ISO3_CODE = "AIA";
     private const int ANGUILLA_NUMERIC_CODE = 660;
-    private const string ANGUILLA_CALLING_CODE = "+1-264";
+    private readonly string[] ANGUILLA_CALLING_CODE = ["+1-264"];
     private const int ANGUILLA_DISTRICT_COUNT = 14;
     private const string ANGUILLA_STATE_TYPE = "District";
 

--- a/src/World.Net.UnitTests/Countries/AntarticaTest.cs
+++ b/src/World.Net.UnitTests/Countries/AntarticaTest.cs
@@ -9,7 +9,7 @@ public class AntarticaTest
     private const string ANTARCTICA_ISO2_CODE = "AQ";
     private const string ANTARCTICA_ISO3_CODE = "ATA";
     private const int ANTARCTICA_NUMERIC_CODE = 10;
-    private const string ANTARCTICA_CALLING_CODE = "+672";
+    private readonly string[] ANTARCTICA_CALLING_CODE = ["+672"];
 
     [Fact]
     public void GetCountry_ReturnsCorrectInformation_ForAntarctica()

--- a/src/World.Net.UnitTests/Countries/AntiguaAndBarbudaTest.cs
+++ b/src/World.Net.UnitTests/Countries/AntiguaAndBarbudaTest.cs
@@ -10,7 +10,7 @@ public sealed class AntiguaAndBarbudaTest
     private const int ANTIGUA_AND_BERBUDA_NUMERIC_CODE = 028;
     private const string ANTIGUA_AND_BERBUDA_ISO2_CODE = "AG";
     private const string ANTIGUA_AND_BERBUDA_ISO3_CODE = "ATG";
-    private const string ANTIGUA_AND_BERBUDA_CALLING_CODE = "+1";
+    private readonly string[] ANTIGUA_AND_BERBUDA_CALLING_CODE = ["+1"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/ArgentinaTest.cs
+++ b/src/World.Net.UnitTests/Countries/ArgentinaTest.cs
@@ -10,7 +10,7 @@ public sealed class ArgentinaTest
     private const int ARGENTINA_NUMERIC_CODE = 032;
     private const string ARGENTINA_ISO2_CODE = "AR";
     private const string ARGENTINA_ISO3_CODE = "ARG";
-    private const string ARGENTINA_CALLING_CODE = "+54";
+    private readonly string[] ARGENTINA_CALLING_CODE = ["+54"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/ArmeniaTest.cs
+++ b/src/World.Net.UnitTests/Countries/ArmeniaTest.cs
@@ -10,7 +10,7 @@ public sealed class ArmeniaTest
     private const int ARMENIA_NUMERIC_CODE = 051;
     private const string ARMENIA_ISO2_CODE = "AM";
     private const string ARMENIA_ISO3_CODE = "ARM";
-    private const string ARMENIA_CALLING_CODE = "+374";
+    private readonly string[] ARMENIA_CALLING_CODE = ["+374"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/ArubaTest.cs
+++ b/src/World.Net.UnitTests/Countries/ArubaTest.cs
@@ -10,7 +10,7 @@ public sealed class ArubaTest
     private const int ARUBA_NUMERIC_CODE = 533;
     private const string ARUBA_ISO2_CODE = "AW";
     private const string ARUBA_ISO3_CODE = "ABW";
-    private const string ARUBA_CALLING_CODE = "+297";
+    private readonly string[] ARUBA_CALLING_CODE = ["+297"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/AustraliaTest.cs
+++ b/src/World.Net.UnitTests/Countries/AustraliaTest.cs
@@ -10,7 +10,7 @@ public sealed class AustraliaTest
     private const int AUSTRALIA_NUMERIC_CODE = 036;
     private const string AUSTRALIA_ISO2_CODE = "AU";
     private const string AUSTRALIA_ISO3_CODE = "AUS";
-    private const string AUSTRALIA_CALLING_CODE = "+61";
+    private readonly string[] AUSTRALIA_CALLING_CODE = ["+61"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/AustriaTest.cs
+++ b/src/World.Net.UnitTests/Countries/AustriaTest.cs
@@ -10,7 +10,7 @@ public sealed class AustriaTest
     private const int AUSTRIA_NUMERIC_CODE = 040;
     private const string AUSTRIA_ISO2_CODE = "AT";
     private const string AUSTRIA_ISO3_CODE = "AUT";
-    private const string AUSTRIA_CALLING_CODE = "+43";
+    private readonly string[] AUSTRIA_CALLING_CODE = ["+43"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/AzerbaijanTest.cs
+++ b/src/World.Net.UnitTests/Countries/AzerbaijanTest.cs
@@ -9,7 +9,7 @@ public sealed class AzerbaijanTest
     private const string AZERBAIJAN_ISO2_CODE = "AZ";
     private const string AZERBAIJAN_ISO3_CODE = "AZE";
     private const int AZERBAIJAN_NUMERIC_CODE = 031;
-    private const string AZERBAIJAN_CALLING_CODE = "+994";
+    private readonly string[] AZERBAIJAN_CALLING_CODE = ["+994"];
     private const int AZERBAIJAN_STATE_COUNT = 75;
     private static readonly string[] VALID_STATE_TYPES = { "District", "Municipality", "Autonomous Republic", };
 

--- a/src/World.Net.UnitTests/Countries/BahrainTest.cs
+++ b/src/World.Net.UnitTests/Countries/BahrainTest.cs
@@ -9,7 +9,7 @@ public sealed class BahrainTest
     private const string BAHRAIN_ISO2_CODE = "BH";
     private const string BAHRAIN_ISO3_CODE = "BHR";
     private const int BAHRAIN_NUMERIC_CODE = 048;
-    private const string BAHRAIN_CALLING_CODE = "+973";
+    private readonly string[] BAHRAIN_CALLING_CODE = ["+973"];
     private const int BAHRAIN_STATE_COUNT = 5;
     private static readonly string[] VALID_STATE_TYPES = { "Governorate", };
 

--- a/src/World.Net.UnitTests/Countries/BangladeshTest.cs
+++ b/src/World.Net.UnitTests/Countries/BangladeshTest.cs
@@ -9,7 +9,7 @@ public sealed class BangladeshTest
     private const int BANGLADESH_NUMERIC_CODE = 050;
     private const string BANGLADESH_ISO2_CODE = "BD";
     private const string BANGLADESH_ISO3_CODE = "BGD";
-    private const string BANGLADESH_CALLING_CODE = "+880";
+    private readonly string[] BANGLADESH_CALLING_CODE = ["+880"];
     private const int BANGLADESH_DIVISION_COUNT = 8;
     private const string BANGLADESH_STATE_TYPE = "Division";
     

--- a/src/World.Net.UnitTests/Countries/BarbadosTest.cs
+++ b/src/World.Net.UnitTests/Countries/BarbadosTest.cs
@@ -9,7 +9,7 @@ public sealed class BarbadosTest
     private const int BARBADOS_NUMERIC_CODE = 052;
     private const string BARBADOS_ISO2_CODE = "BB";
     private const string BARBADOS_ISO3_CODE = "BRB";
-    private const string BARBADOS_CALLING_CODE = "+1-246";
+    private readonly string[] BARBADOS_CALLING_CODE = ["+1-246"];
     private const int BARBADOS_PARISH_COUNT = 11;
     private const string BARBADOS_STATE_TYPE = "Parish";
     

--- a/src/World.Net.UnitTests/Countries/BelarusTest.cs
+++ b/src/World.Net.UnitTests/Countries/BelarusTest.cs
@@ -9,7 +9,7 @@ public sealed class BelarusTest
     private const int BELARUS_NUMERIC_CODE = 112;
     private const string BELARUS_ISO2_CODE = "BY";
     private const string BELARUS_ISO3_CODE = "BLR";
-    private const string BELARUS_CALLING_CODE = "+375";
+    private readonly string[] BELARUS_CALLING_CODE = ["+375"];
     private const int BELARUS_PARISH_COUNT = 7;
     
     [Fact]

--- a/src/World.Net.UnitTests/Countries/BelgiumTest.cs
+++ b/src/World.Net.UnitTests/Countries/BelgiumTest.cs
@@ -9,7 +9,7 @@ public sealed class BelgiumTest
     private const int BELGIUM_NUMERIC_CODE = 056;
     private const string BELGIUM_ISO2_CODE = "BE";
     private const string BELGIUM_ISO3_CODE = "BEL";
-    private const string BELGIUM_CALLING_CODE = "+32";
+    private readonly string[] BELGIUM_CALLING_CODE = ["+32"];
     private const int BELGIUM_REGION_COUNT = 3;
     private const int BELGIUM_PROVINCE_COUNT = 10;
     private const string BELGIUM_REGION_TYPE = "Region";

--- a/src/World.Net.UnitTests/Countries/BelizeTest.cs
+++ b/src/World.Net.UnitTests/Countries/BelizeTest.cs
@@ -9,7 +9,7 @@ public sealed class BelizeTest
     private const int BELIZE_NUMERIC_CODE = 084;
     private const string BELIZE_ISO2_CODE = "BZ";
     private const string BELIZE_ISO3_CODE = "BLZ";
-    private const string BELIZE_CALLING_CODE = "+501";
+    private readonly string[] BELIZE_CALLING_CODE = ["+501"];
     private const int BELIZE_DISTRICT_COUNT = 6;
     private const string BELIZE_STATE_TYPE = "District";
     

--- a/src/World.Net.UnitTests/Countries/BeninTest.cs
+++ b/src/World.Net.UnitTests/Countries/BeninTest.cs
@@ -9,7 +9,7 @@ public sealed class BeninTest
     private const int BENIN_NUMERIC_CODE = 204;
     private const string BENIN_ISO2_CODE = "BJ";
     private const string BENIN_ISO3_CODE = "BEN";
-    private const string BENIN_CALLING_CODE = "+229";
+    private readonly string[] BENIN_CALLING_CODE = ["+229"];
     private const int BENIN_DEPARTMENT_COUNT = 12;
     private const string BENIN_STATE_TYPE = "Department";
     

--- a/src/World.Net.UnitTests/Countries/BermudaTest.cs
+++ b/src/World.Net.UnitTests/Countries/BermudaTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace World.Net.UnitTests.Countries;
 
-internal static class BermudaTestData
+public class BermudaTestData
 {
     internal const string COUNTRY_NAME = "Bermuda";
     internal const string NATIVE_NAME = "Bermuda";
@@ -9,7 +9,7 @@ internal static class BermudaTestData
     internal const string ISO2_CODE = "BM";
     internal const string ISO3_CODE = "BMU";
     internal const int NUMERIC_CODE = 60;
-    internal const string CALLING_CODE = "+1-441";
+    internal static readonly string[] CALLING_CODE = ["+1-441"];
     internal const string STATE_TYPE = "Municipality";
     internal const int EXPECTED_STATE_COUNT = 9;
 }

--- a/src/World.Net.UnitTests/Countries/BhutanTest.cs
+++ b/src/World.Net.UnitTests/Countries/BhutanTest.cs
@@ -9,7 +9,7 @@ internal static class BhutanTestData
     internal const string ISO2_CODE = "BT";
     internal const string ISO3_CODE = "BTN";
     internal const int NUMERIC_CODE = 64;
-    internal const string CALLING_CODE = "+975";
+    internal static readonly string[] CALLING_CODE = ["+975"];
     internal const string STATE_TYPE = "District";
     internal const int EXPECTED_STATE_COUNT = 20;
 }

--- a/src/World.Net.UnitTests/Countries/BoliviaTests.cs
+++ b/src/World.Net.UnitTests/Countries/BoliviaTests.cs
@@ -9,7 +9,7 @@ internal static class BoliviaTestData
     internal const string ISO2_CODE = "BO";
     internal const string ISO3_CODE = "BOL";
     internal const int NUMERIC_CODE = 68;
-    internal const string CALLING_CODE = "+591";
+    internal static readonly string[] CALLING_CODE = ["+591"];
     internal const string STATE_TYPE = "Department";
     internal const int EXPECTED_STATE_COUNT = 9;
 }

--- a/src/World.Net.UnitTests/Countries/BosniaAndHerzegovinaTest.cs
+++ b/src/World.Net.UnitTests/Countries/BosniaAndHerzegovinaTest.cs
@@ -10,7 +10,7 @@ public sealed class BosniaAndHerzegovinaTest
     private const int BOSNIA_AND_HERZEGOVINA_NUMERIC_CODE = 070;
     private const string BOSNIA_AND_HERZEGOVINA_ISO2_CODE = "BA";
     private const string BOSNIA_AND_HERZEGOVINA_ISO3_CODE = "BIH";
-    private const string BOSNIA_AND_HERZEGOVINA_CALLING_CODE = "+387";
+    private static readonly string[] BOSNIA_AND_HERZEGOVINA_CALLING_CODE = ["+387"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/BotswanaTest.cs
+++ b/src/World.Net.UnitTests/Countries/BotswanaTest.cs
@@ -10,7 +10,7 @@ public sealed class BotswanaTest
     private const int BOTSWANA_NUMERIC_CODE = 072;
     private const string BOTSWANA_ISO2_CODE = "BW";
     private const string BOTSWANA_ISO3_CODE = "BWA";
-    private const string BOTSWANA_CALLING_CODE = "+267";
+    private readonly string[] BOTSWANA_CALLING_CODE = ["+267"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/BouvetIslandTest.cs
+++ b/src/World.Net.UnitTests/Countries/BouvetIslandTest.cs
@@ -9,7 +9,7 @@ public sealed class BouvetIslandTest
     private const int BOUVETISLAND_NUMERIC_CODE = 074;
     private const string BOUVETISLAND_ISO2_CODE = "BV";
     private const string BOUVETISLAND_ISO3_CODE = "BVT";
-    private const string BOUVETISLAND_CALLING_CODE = "+0055";
+    private readonly string[] BOUVETISLAND_CALLING_CODE = ["+0055"];
 
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/BrazilTest.cs
+++ b/src/World.Net.UnitTests/Countries/BrazilTest.cs
@@ -10,7 +10,7 @@
         private const int BRAZIL_NUMERIC_CODE = 076;
         private const string BRAZIL_ISO2_CODE = "BR";
         private const string BRAZIL_ISO3_CODE = "BRA";
-        private const string BRAZIL_CALLING_CODE = "+55";
+        private readonly string[] BRAZIL_CALLING_CODE = ["+55"];
 
         [Fact]
         public void GetCountry_ReturnsCorrectInformation_for_Brazil()

--- a/src/World.Net.UnitTests/Countries/BritishIndianOceanTerritoryTest.cs
+++ b/src/World.Net.UnitTests/Countries/BritishIndianOceanTerritoryTest.cs
@@ -9,7 +9,7 @@
         private const int BRITISH_INDIAN_OCEAN_TERRITORY_NUMERIC_CODE = 086;
         private const string BRITISH_INDIAN_OCEAN_TERRITORY_ISO2_CODE = "IO";
         private const string BRITISH_INDIAN_OCEAN_TERRITORY_ISO3_CODE = "IOT";
-        private const string BRITISH_INDIAN_OCEAN_TERRITORY_CALLING_CODE = "+246";
+        private readonly string[] BRITISH_INDIAN_OCEAN_TERRITORY_CALLING_CODE = ["+246"];
 
         [Fact]
         public void GetCountry_ReturnsCorrectInformation_for_BritishIndianOceanTerritory()

--- a/src/World.Net.UnitTests/Countries/BruneiTest.cs
+++ b/src/World.Net.UnitTests/Countries/BruneiTest.cs
@@ -10,7 +10,7 @@
         private const int BRUNEI_NUMERIC_CODE = 096;
         private const string BRUNEI_ISO2_CODE = "BN";
         private const string BRUNEI_ISO3_CODE = "BRN";
-        private const string BRUNEI_CALLING_CODE = "+673";
+        private readonly string[] BRUNEI_CALLING_CODE = ["+673"];
 
         [Fact]
         public void GetCountry_ReturnsCorrectInformation_for_Brunei()

--- a/src/World.Net.UnitTests/Countries/BulgariaTest.cs
+++ b/src/World.Net.UnitTests/Countries/BulgariaTest.cs
@@ -10,7 +10,7 @@
         private const int BULGARIA_NUMERIC_CODE = 100;
         private const string BULGARIA_ISO2_CODE = "BG";
         private const string BULGARIA_ISO3_CODE = "BGR";
-        private const string BULGARIA_CALLING_CODE = "+359";
+        private readonly string[] BULGARIA_CALLING_CODE = ["+359"];
 
         [Fact]
         public void GetCountry_ReturnsCorrectInformation_for_Bulgaria()

--- a/src/World.Net.UnitTests/Countries/BurkinaFasoTest.cs
+++ b/src/World.Net.UnitTests/Countries/BurkinaFasoTest.cs
@@ -10,7 +10,7 @@
         private const int BURKINA_FASO_NUMERIC_CODE = 854;
         private const string BURKINA_FASO_ISO2_CODE = "BF";
         private const string BURKINA_FASO_ISO3_CODE = "BFA";
-        private const string BURKINA_FASO_CALLING_CODE = "+226";
+        private readonly string[] BURKINA_FASO_CALLING_CODE = ["+226"];
 
         [Fact]
         public void GetCountry_ReturnsCorrectInformation_for_BurkinaFaso()

--- a/src/World.Net.UnitTests/Countries/BurundiTest.cs
+++ b/src/World.Net.UnitTests/Countries/BurundiTest.cs
@@ -9,7 +9,7 @@ public sealed class BurundiTest
     private const string BURUNDI_ISO2_CODE = "BI";
     private const string BURUNDI_ISO3_CODE = "BDI";
     private const int BURUNDI_NUMERIC_CODE = 108;
-    private const string BURUNDI_CALLING_CODE = "+257";
+    private readonly string[] BURUNDI_CALLING_CODE = ["+257"];
     private const int BURUNDI_STATE_COUNT = 18;
     private static readonly string[] VALID_STATE_TYPES = { "Province" };
 

--- a/src/World.Net.UnitTests/Countries/CambodiaTest.cs
+++ b/src/World.Net.UnitTests/Countries/CambodiaTest.cs
@@ -9,7 +9,7 @@ public sealed class CambodiaTest
     private const string CAMBODIA_ISO2_CODE = "KH";
     private const string CAMBODIA_ISO3_CODE = "KHM";
     private const int CAMBODIA_NUMERIC_CODE = 116;
-    private const string CAMBODIA_CALLING_CODE = "+855";
+    private readonly string[] CAMBODIA_CALLING_CODE = ["+855"];
     private const int CAMBODIA_STATE_COUNT = 25;
     private static readonly string[] VALID_STATE_TYPES = { "Province", "Municipality" };
 

--- a/src/World.Net.UnitTests/Countries/CameroonTest.cs
+++ b/src/World.Net.UnitTests/Countries/CameroonTest.cs
@@ -9,7 +9,7 @@ public sealed class CameroonTest
     private const string CAMEROON_ISO2_CODE = "CM";
     private const string CAMEROON_ISO3_CODE = "CMR";
     private const int CAMEROON_NUMERIC_CODE = 120;
-    private const string CAMEROON_CALLING_CODE = "+237";
+    private readonly string[] CAMEROON_CALLING_CODE = ["+237"];
     private const int CAMEROON_STATE_COUNT = 10;
     private static readonly string[] VALID_STATE_TYPES = { "Region" };
 

--- a/src/World.Net.UnitTests/Countries/CanadaTest.cs
+++ b/src/World.Net.UnitTests/Countries/CanadaTest.cs
@@ -9,7 +9,7 @@ public sealed class CanadaTest
     private const string CANADA_ISO2_CODE = "CA";
     private const string CANADA_ISO3_CODE = "CAN";
     private const int CANADA_NUMERIC_CODE = 124;
-    private const string CANADA_CALLING_CODE = "+1";
+    private readonly string[] CANADA_CALLING_CODE = ["+1"];
     private const int CANADA_STATE_COUNT = 13;
     private static readonly string[] VALID_STATE_TYPES = { "Province", "Territory" };
 

--- a/src/World.Net.UnitTests/Countries/CapeVerdeTest.cs
+++ b/src/World.Net.UnitTests/Countries/CapeVerdeTest.cs
@@ -9,7 +9,7 @@ public sealed class CapeVerdeTest
     private const string CAPEVERDE_ISO2_CODE = "CV";
     private const string CAPEVERDE_ISO3_CODE = "CPV";
     private const int CAPEVERDE_NUMERIC_CODE = 132;
-    private const string CAPEVERDE_CALLING_CODE = "+238";
+    private readonly string[] CAPEVERDE_CALLING_CODE = ["+238"];
     private const int CAPEVERDE_STATE_COUNT = 22;
     private static readonly string[] VALID_STATE_TYPES = { "Municipality" };
 

--- a/src/World.Net.UnitTests/Countries/CaymanIslandsTest.cs
+++ b/src/World.Net.UnitTests/Countries/CaymanIslandsTest.cs
@@ -9,7 +9,7 @@
         private const string CAYMAN_ISLANDS_ISO2_CODE = "KY";
         private const string CAYMAN_ISLANDS_ISO3_CODE = "CYM";
         private const int CAYMAN_ISLANDS_NUMERIC_CODE = 136;
-        private const string CAYMAN_ISLANDS_CALLING_CODE = "+1-345";
+        private readonly string[] CAYMAN_ISLANDS_CALLING_CODE = ["+1-345"];
         private const int CAYMAN_ISLANDS_STATE_COUNT = 3;
         private static readonly string[] VALID_STATE_TYPES = { "District" };
 

--- a/src/World.Net.UnitTests/Countries/CentralAfricanRepublicTest.cs
+++ b/src/World.Net.UnitTests/Countries/CentralAfricanRepublicTest.cs
@@ -9,7 +9,7 @@ public sealed class CentralAfricanRepublicTest
     private const string CAR_ISO2_CODE = "CF";
     private const string CAR_ISO3_CODE = "CAF";
     private const int CAR_NUMERIC_CODE = 140;
-    private const string CAR_CALLING_CODE = "+236";
+    private readonly string[] CAR_CALLING_CODE = ["+236"];
     private const int CAR_STATE_COUNT = 14;
     private static readonly string[] VALID_STATE_TYPES = { "Prefecture", "Capital District" };
 

--- a/src/World.Net.UnitTests/Countries/ChadTest.cs
+++ b/src/World.Net.UnitTests/Countries/ChadTest.cs
@@ -9,7 +9,7 @@ public sealed class ChadTest
     private const string CHAD_ISO2_CODE = "TD";
     private const string CHAD_ISO3_CODE = "TCD";
     private const int CHAD_NUMERIC_CODE = 148;
-    private const string CHAD_CALLING_CODE = "+235";
+    private readonly string[] CHAD_CALLING_CODE = ["+235"];
     private const int CHAD_STATE_COUNT = 23;
     private static readonly string[] VALID_STATE_TYPES = { "Region" };
 

--- a/src/World.Net.UnitTests/Countries/ChileTest.cs
+++ b/src/World.Net.UnitTests/Countries/ChileTest.cs
@@ -9,7 +9,7 @@ public sealed class ChileTest
     private const string CHILE_ISO2_CODE = "CL";
     private const string CHILE_ISO3_CODE = "CHL";
     private const int CHILE_NUMERIC_CODE = 152;
-    private const string CHILE_CALLING_CODE = "+56";
+    private readonly string[] CHILE_CALLING_CODE = ["+56"];
     private const int CHILE_STATE_COUNT = 16;
     private static readonly string[] VALID_STATE_TYPES = { "Region" };
 

--- a/src/World.Net.UnitTests/Countries/ChinaTest.cs
+++ b/src/World.Net.UnitTests/Countries/ChinaTest.cs
@@ -9,7 +9,7 @@ public sealed class ChinaTest
     private const string CHINA_ISO2_CODE = "CN";
     private const string CHINA_ISO3_CODE = "CHN";
     private const int CHINA_NUMERIC_CODE = 156;
-    private const string CHINA_CALLING_CODE = "+86";
+    private readonly string[] CHINA_CALLING_CODE = ["+86"];
     private const int CHINA_STATE_COUNT = 34; // 23 Provinces, 4 Municipalities, 5 Autonomous Regions, 2 SAR
     private static readonly string[] VALID_STATE_TYPES = { "Province", "Municipality", "Autonomous Region", "Special Administrative Region" };
 

--- a/src/World.Net.UnitTests/Countries/ChristmasIslandTest.cs
+++ b/src/World.Net.UnitTests/Countries/ChristmasIslandTest.cs
@@ -9,7 +9,7 @@ public sealed class ChristmasIslandTest
     private const string CHRISTMAS_ISLAND_ISO2_CODE = "CX";
     private const string CHRISTMAS_ISLAND_ISO3_CODE = "CXR";
     private const int CHRISTMAS_ISLAND_NUMERIC_CODE = 162;
-    private const string CHRISTMAS_ISLAND_CALLING_CODE = "+61";
+    private readonly string[] CHRISTMAS_ISLAND_CALLING_CODE = ["+61"];
     private static readonly string[] VALID_STATE_TYPES = { };
 
     [Fact]

--- a/src/World.Net.UnitTests/Countries/CocosKeelingIslandsTest.cs
+++ b/src/World.Net.UnitTests/Countries/CocosKeelingIslandsTest.cs
@@ -9,7 +9,7 @@ public sealed class CocosKeelingIslandsTest
     private const string COCOS_ISO2_CODE = "CC";
     private const string COCOS_ISO3_CODE = "CCK";
     private const int COCOS_NUMERIC_CODE = 166;
-    private const string COCOS_CALLING_CODE = "+61";
+    private readonly string[] COCOS_CALLING_CODE = ["+61"];
     private const int COCOS_STATE_COUNT = 2;
     private static readonly string[] VALID_STATE_TYPES = { "Island" };
 

--- a/src/World.Net.UnitTests/Countries/ColombiaTest.cs
+++ b/src/World.Net.UnitTests/Countries/ColombiaTest.cs
@@ -9,7 +9,7 @@ public sealed class ColombiaTest
     private const string COLOMBIA_ISO2_CODE = "CO";
     private const string COLOMBIA_ISO3_CODE = "COL";
     private const int COLOMBIA_NUMERIC_CODE = 170;
-    private const string COLOMBIA_CALLING_CODE = "+57";
+    private readonly string[] COLOMBIA_CALLING_CODE = ["+57"];
     private const int COLOMBIA_STATE_COUNT = 32;
     private static readonly string[] VALID_STATE_TYPES = { "Department", "Capital District" };
 

--- a/src/World.Net.UnitTests/Countries/ComorosTest.cs
+++ b/src/World.Net.UnitTests/Countries/ComorosTest.cs
@@ -9,7 +9,7 @@ public sealed class ComorosTest
     private const string COMOROS_ISO2_CODE = "KM";
     private const string COMOROS_ISO3_CODE = "COM";
     private const int COMOROS_NUMERIC_CODE = 174;
-    private const string COMOROS_CALLING_CODE = "+269";
+    private readonly string[] COMOROS_CALLING_CODE = ["+269"];
     private const int COMOROS_STATE_COUNT = 3;
     private static readonly string[] VALID_STATE_TYPES = { "Autonomous Island" };
     

--- a/src/World.Net.UnitTests/Countries/CongoTest.cs
+++ b/src/World.Net.UnitTests/Countries/CongoTest.cs
@@ -10,7 +10,7 @@
         private const int CONGO_NUMERIC_CODE = 178;
         private const string CONGO_ISO2_CODE = "CG";
         private const string CONGO_ISO3_CODE = "COG";
-        private const string CONGO_CALLING_CODE = "+242";
+        private readonly string[] CONGO_CALLING_CODE = ["+242"];
 
 
         [Fact]

--- a/src/World.Net.UnitTests/Countries/CookIslandsTest.cs
+++ b/src/World.Net.UnitTests/Countries/CookIslandsTest.cs
@@ -9,7 +9,7 @@
         private const int COOKISLANDS_NUMERIC_CODE = 184;
         private const string COOKISLANDS_ISO2_CODE = "CK";
         private const string COOKISLANDS_ISO3_CODE = "COK";
-        private const string COOKISLANDS_CALLING_CODE = "+682";
+        private readonly string[] COOKISLANDS_CALLING_CODE = ["+682"];
 
 
         [Fact]

--- a/src/World.Net.UnitTests/Countries/CostaRicaTest.cs
+++ b/src/World.Net.UnitTests/Countries/CostaRicaTest.cs
@@ -10,7 +10,7 @@
         private const int COSTARICA_NUMERIC_CODE = 188;
         private const string COSTARICA_ISO2_CODE = "CR";
         private const string COSTARICA_ISO3_CODE = "CRI";
-        private const string COSTARICA_CALLING_CODE = "+506";
+        private readonly string[] COSTARICA_CALLING_CODE = ["+506"];
 
 
         [Fact]

--- a/src/World.Net.UnitTests/Countries/CoteDIvoireTest.cs
+++ b/src/World.Net.UnitTests/Countries/CoteDIvoireTest.cs
@@ -10,7 +10,7 @@
         private const int COTEDIVOIRE_NUMERIC_CODE = 384;
         private const string COTEDIVOIRE_ISO2_CODE = "CI";
         private const string COTEDIVOIRE_ISO3_CODE = "CIV";
-        private const string COTEDIVOIRE_CALLING_CODE = "+225";
+        private readonly string[] COTEDIVOIRE_CALLING_CODE = ["+225"];
 
 
         [Fact]

--- a/src/World.Net.UnitTests/Countries/CroatiaTest.cs
+++ b/src/World.Net.UnitTests/Countries/CroatiaTest.cs
@@ -9,7 +9,7 @@ public sealed class CroatiaTest
     private const string CROATIA_ISO2_CODE = "HR";
     private const string CROATIA_ISO3_CODE = "HRV";
     private const int CROATIA_NUMERIC_CODE = 191;
-    private const string CROATIA_CALLING_CODE = "+385";
+    private readonly string[] CROATIA_CALLING_CODE = ["+385"];
     private const int CROATIA_STATE_COUNT = 21;
     private static readonly string[] VALID_STATE_TYPES = { "City", "County" };
     

--- a/src/World.Net.UnitTests/Countries/CubaTest.cs
+++ b/src/World.Net.UnitTests/Countries/CubaTest.cs
@@ -9,7 +9,7 @@ public sealed class CubaTest
     private const string CUBA_ISO2_CODE = "CU";
     private const string CUBA_ISO3_CODE = "CUB";
     private const int CUBA_NUMERIC_CODE = 192;
-    private const string CUBA_CALLING_CODE = "+53";
+    private readonly string[] CUBA_CALLING_CODE = ["+53"];
     private const int CUBA_STATE_COUNT = 16;
     private static readonly string[] VALID_STATE_TYPES = { "Province", "Special Municipality" };
     

--- a/src/World.Net.UnitTests/Countries/CuraçaoTest.cs
+++ b/src/World.Net.UnitTests/Countries/CuraçaoTest.cs
@@ -9,7 +9,7 @@ public sealed class CuraçaoTest
     private const string CURACAO_ISO2_CODE = "CW";
     private const string CURACAO_ISO3_CODE = "CUW";
     private const int CURACAO_NUMERIC_CODE = 531;
-    private const string CURACAO_CALLING_CODE = "+599";
+    private readonly string[] CURACAO_CALLING_CODE = ["+599"];
     private const int CURACAO_STATE_COUNT = 1;
     private static readonly string[] VALID_STATE_TYPES = { "Country" };
     

--- a/src/World.Net.UnitTests/Countries/CyprusTest.cs
+++ b/src/World.Net.UnitTests/Countries/CyprusTest.cs
@@ -9,7 +9,7 @@ public sealed class CyprusTest
     private const string CYPRUS_ISO2_CODE = "CY";
     private const string CYPRUS_ISO3_CODE = "CYP";
     private const int CYPRUS_NUMERIC_CODE = 196;
-    private const string CYPRUS_CALLING_CODE = "+357";
+    private readonly string[] CYPRUS_CALLING_CODE = ["+357"];
     private const int CYPRUS_STATE_COUNT = 6;
     private static readonly string[] VALID_STATE_TYPES = { "District" };
     

--- a/src/World.Net.UnitTests/Countries/CzechRepublicTest.cs
+++ b/src/World.Net.UnitTests/Countries/CzechRepublicTest.cs
@@ -9,7 +9,7 @@ public sealed class CzechRepublicTest
     private const string CZECHREPUBLIC_ISO2_CODE = "CZ";
     private const string CZECHREPUBLIC_ISO3_CODE = "CZE";
     private const int CZECHREPUBLIC_NUMERIC_CODE = 203;
-    private const string CZECHREPUBLIC_CALLING_CODE = "+420";
+    private readonly string[] CZECHREPUBLIC_CALLING_CODE = ["+420"];
     private const int CZECHREPUBLIC_STATE_COUNT = 14;
     private static readonly string[] VALID_STATE_TYPES = { "Region", "Capital City" };
 

--- a/src/World.Net.UnitTests/Countries/TheBahamasTest.cs
+++ b/src/World.Net.UnitTests/Countries/TheBahamasTest.cs
@@ -9,7 +9,7 @@ public sealed class TheBahamasTest
     private const string THEBAHAMAS_ISO2_CODE = "BS";
     private const string THEBAHAMAS_ISO3_CODE = "BHS";
     private const int THEBAHAMAS_NUMERIC_CODE = 044;
-    private const string THEBAHAMAS_CALLING_CODE = "+1 242";
+    private readonly string[] THEBAHAMAS_CALLING_CODE = ["+1 242"];
     private const int THEBAHAMAS_STATE_COUNT = 42;
     private static readonly string[] VALID_STATE_TYPES = { "District", "Island" };
 

--- a/src/World.Net.UnitTests/CountryProviderTest.cs
+++ b/src/World.Net.UnitTests/CountryProviderTest.cs
@@ -8,7 +8,7 @@ public sealed class CountryProviderTest
     private const string AFGHANISTAN_ISO3_CODE = "AFG";
     private const string AFGHANISTAN_CAPITAL = "Kabul";
     private const int AFGHANISTAN_NUMERIC_CODE = 004;
-    private const string AFGHANISTAN_CALLING_CODE = "+93";
+    private readonly string[] AFGHANISTAN_CALLING_CODE = ["+93"];
     private const int AFGHANISTAN_STATE_COUNT = 34;
     private const string AFGHANISTAN_NAME = "Afghanistan";
     private const string AFGHANISTAN_NATIVE_NAME = "افغانستان";

--- a/src/World.Net/Countries/Afghanistan.cs
+++ b/src/World.Net/Countries/Afghanistan.cs
@@ -29,7 +29,7 @@ internal sealed class Afghanistan : ICountry
     public string ISO3Code { get; } = "AFG";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+93";
+    public string[] CallingCode { get; } = ["+93"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/AlandIslands.cs
+++ b/src/World.Net/Countries/AlandIslands.cs
@@ -27,7 +27,7 @@ internal sealed class AlandIslands : ICountry
     public string ISO3Code { get; } = "ALA";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+358";
+    public string[] CallingCode { get; } = ["+358"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States  { get; } =

--- a/src/World.Net/Countries/Albania.cs
+++ b/src/World.Net/Countries/Albania.cs
@@ -27,7 +27,7 @@ internal sealed class Albania : ICountry
     public string ISO3Code { get; } = "ALB";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+355";
+    public string[] CallingCode { get; } = ["+355"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Algeria.cs
+++ b/src/World.Net/Countries/Algeria.cs
@@ -29,7 +29,7 @@ internal sealed class Algeria : ICountry
     public string ISO3Code { get; } = "DZA";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+213";
+    public string[] CallingCode { get; } = ["+213"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/AmericanSamoa.cs
+++ b/src/World.Net/Countries/AmericanSamoa.cs
@@ -29,7 +29,7 @@ internal sealed class AmericanSamoa : ICountry
     public string ISO3Code { get; } = "ASM";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+1";
+    public string[] CallingCode { get; } = ["+1"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Andorra.cs
+++ b/src/World.Net/Countries/Andorra.cs
@@ -29,7 +29,7 @@ internal sealed class Andorra : ICountry
     public string ISO3Code { get; } = "AND";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+376";
+    public string[] CallingCode { get; } = ["+376"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Angola.cs
+++ b/src/World.Net/Countries/Angola.cs
@@ -27,7 +27,7 @@ internal sealed class Angola : ICountry
     public string ISO3Code { get; } = "AGO";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+244";
+    public string[] CallingCode { get; } = ["+244"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Anguilla.cs
+++ b/src/World.Net/Countries/Anguilla.cs
@@ -27,7 +27,7 @@ internal sealed class Anguilla : ICountry
     public string ISO3Code { get; } = "AIA";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+1-264";
+    public string[] CallingCode { get; } = ["+1-264"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Antarctica.cs
+++ b/src/World.Net/Countries/Antarctica.cs
@@ -27,7 +27,7 @@ internal sealed class Antarctica : ICountry
     public string ISO3Code { get; } = "ATA";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+672";
+    public string[] CallingCode { get; } = ["+672"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } = [];

--- a/src/World.Net/Countries/AntiguaAndBarbuda.cs
+++ b/src/World.Net/Countries/AntiguaAndBarbuda.cs
@@ -27,7 +27,7 @@ internal sealed class AntiguaAndBarbuda : ICountry
     public string ISO3Code { get; } = "ATG";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+1";
+    public string[] CallingCode { get; } = ["+1"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Argentina.cs
+++ b/src/World.Net/Countries/Argentina.cs
@@ -27,7 +27,7 @@ internal sealed class Argentina : ICountry
     public string ISO3Code { get; } = "ARG";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+54";
+    public string[] CallingCode { get; } = ["+54"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Armenia.cs
+++ b/src/World.Net/Countries/Armenia.cs
@@ -27,7 +27,7 @@ internal sealed class Armenia : ICountry
     public string ISO3Code { get; } = "ARM";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+374";
+    public string[] CallingCode { get; } = ["+374"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Aruba.cs
+++ b/src/World.Net/Countries/Aruba.cs
@@ -27,7 +27,7 @@ internal sealed class Aruba : ICountry
     public string ISO3Code { get; } = "ABW";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+297";
+    public string[] CallingCode { get; } = ["+297"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Australia.cs
+++ b/src/World.Net/Countries/Australia.cs
@@ -27,7 +27,7 @@ internal sealed class Australia : ICountry
     public string ISO3Code { get; } = "AUS";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+61";
+    public string[] CallingCode { get; } = ["+61"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Austria.cs
+++ b/src/World.Net/Countries/Austria.cs
@@ -27,7 +27,7 @@ internal sealed class Austria : ICountry
     public string ISO3Code { get; } = "AUT";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+43";
+    public string[] CallingCode { get; } = ["+43"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Azerbaijan.cs
+++ b/src/World.Net/Countries/Azerbaijan.cs
@@ -27,7 +27,7 @@ internal sealed class Azerbaijan : ICountry
     public string ISO3Code { get; } = "AZE";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+994";
+    public string[] CallingCode { get; } = ["+994"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Bahrain.cs
+++ b/src/World.Net/Countries/Bahrain.cs
@@ -27,7 +27,7 @@ internal sealed class Bahrain : ICountry
     public string ISO3Code { get; } = "BHR";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+973";
+    public string[] CallingCode { get; } = ["+973"];
 
     //<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Bangladesh.cs
+++ b/src/World.Net/Countries/Bangladesh.cs
@@ -27,7 +27,7 @@ internal sealed class Bangladesh : ICountry
     public string ISO3Code { get; } = "BGD";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+880";
+    public string[] CallingCode { get; } = ["+880"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Barbados.cs
+++ b/src/World.Net/Countries/Barbados.cs
@@ -27,7 +27,7 @@ internal sealed class Barbados : ICountry
     public string ISO3Code { get; } = "BRB";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+1-246";
+    public string[] CallingCode { get; } = ["+1-246"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Belarus.cs
+++ b/src/World.Net/Countries/Belarus.cs
@@ -27,7 +27,7 @@ internal sealed class Belarus : ICountry
     public string ISO3Code { get; } = "BLR";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+375";
+    public string[] CallingCode { get; } = ["+375"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Belgium.cs
+++ b/src/World.Net/Countries/Belgium.cs
@@ -27,7 +27,7 @@ internal sealed class Belgium : ICountry
     public string ISO3Code { get; } = "BEL";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+32";
+    public string[] CallingCode { get; } = ["+32"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Belize.cs
+++ b/src/World.Net/Countries/Belize.cs
@@ -27,7 +27,7 @@ internal sealed class Belize : ICountry
     public string ISO3Code { get; } = "BLZ";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+501";
+    public string[] CallingCode { get; } = ["+501"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Benin.cs
+++ b/src/World.Net/Countries/Benin.cs
@@ -27,7 +27,7 @@ internal sealed class Benin : ICountry
     public string ISO3Code { get; } = "BEN";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+229";
+    public string[] CallingCode { get; } = ["+229"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Bermuda.cs
+++ b/src/World.Net/Countries/Bermuda.cs
@@ -27,7 +27,7 @@ internal sealed class Bermuda : ICountry
     public string ISO3Code { get; } = "BMU";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+1-441";
+    public string[] CallingCode { get; } = ["+1-441"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Bhutan.cs
+++ b/src/World.Net/Countries/Bhutan.cs
@@ -27,7 +27,7 @@ internal sealed class Bhutan : ICountry
     public string ISO3Code { get; } = "BTN";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+975";
+    public string[] CallingCode { get; } = ["+975"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Bolivia.cs
+++ b/src/World.Net/Countries/Bolivia.cs
@@ -28,7 +28,7 @@ internal sealed class Bolivia : ICountry
     public string ISO3Code { get; } = "BOL";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+591";
+    public string[] CallingCode { get; } = ["+591"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/BosniaAndHerzegovina.cs
+++ b/src/World.Net/Countries/BosniaAndHerzegovina.cs
@@ -27,7 +27,7 @@ internal sealed class BosniaAndHerzegovina : ICountry
     public string ISO3Code { get; } = "BIH";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+387";
+    public string[] CallingCode { get; } = ["+387"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Botswana.cs
+++ b/src/World.Net/Countries/Botswana.cs
@@ -27,7 +27,7 @@ internal sealed class Botswana : ICountry
     public string ISO3Code { get; } = "BWA";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+267";
+    public string[] CallingCode { get; } = ["+267"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/BouvetIsland.cs
+++ b/src/World.Net/Countries/BouvetIsland.cs
@@ -26,7 +26,7 @@ internal sealed class BouvetIsland : ICountry
     public string ISO3Code { get; } = "BVT";
 
     ///<inheritdoc/>
-    public string CallingCode { get; } = "+0055";
+    public string[] CallingCode { get; } = ["+0055"];
 
     ///<inheritdoc/>
     public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Brazil.cs
+++ b/src/World.Net/Countries/Brazil.cs
@@ -27,7 +27,7 @@
         public string ISO3Code { get; } = "BRA";
 
         ///<inheritdoc/>
-        public string CallingCode { get; } = "+55";
+        public string[] CallingCode { get; } = ["+55"];
 
         ///<inheritdoc/>
         public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/BritishIndianOceanTerritory.cs
+++ b/src/World.Net/Countries/BritishIndianOceanTerritory.cs
@@ -27,7 +27,7 @@
         public string ISO3Code { get; } = "IOT";
 
         ///<inheritdoc/>
-        public string CallingCode { get; } = "+246";
+        public string[] CallingCode { get; } = ["+246"];
 
         ///<inheritdoc/>
         public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Brunei.cs
+++ b/src/World.Net/Countries/Brunei.cs
@@ -27,7 +27,7 @@
         public string ISO3Code { get; } = "BRN";
 
         ///<inheritdoc/>
-        public string CallingCode { get; } = "+673";
+        public string[] CallingCode { get; } = ["+673"];
 
         ///<inheritdoc/>
         public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Bulgaria.cs
+++ b/src/World.Net/Countries/Bulgaria.cs
@@ -27,7 +27,7 @@
         public string ISO3Code { get; } = "BGR";
 
         ///<inheritdoc/>
-        public string CallingCode { get; } = "+359";
+        public string[] CallingCode { get; } = ["+359"];
 
         ///<inheritdoc/>
         public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/BurkinaFaso.cs
+++ b/src/World.Net/Countries/BurkinaFaso.cs
@@ -27,7 +27,7 @@
         public string ISO3Code { get; } = "BFA";
 
         ///<inheritdoc/>
-        public string CallingCode { get; } = "+226";
+        public string[] CallingCode { get; } = ["+226"];
 
         ///<inheritdoc/>
         public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Burundi.cs
+++ b/src/World.Net/Countries/Burundi.cs
@@ -27,7 +27,7 @@ internal sealed class Burundi : ICountry
     public string ISO3Code { get; } = "BDI";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+257";
+    public string[] CallingCode { get; } = ["+257"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Cambodia.cs
+++ b/src/World.Net/Countries/Cambodia.cs
@@ -27,7 +27,7 @@ internal sealed class Cambodia : ICountry
     public string ISO3Code { get; } = "KHM";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+855";
+    public string[] CallingCode { get; } = ["+855"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Cameroon.cs
+++ b/src/World.Net/Countries/Cameroon.cs
@@ -27,7 +27,7 @@ internal sealed class Cameroon : ICountry
     public string ISO3Code { get; } = "CMR";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+237";
+    public string[] CallingCode { get; } = ["+237"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Canada.cs
+++ b/src/World.Net/Countries/Canada.cs
@@ -27,7 +27,7 @@ internal sealed class Canada : ICountry
     public string ISO3Code { get; } = "CAN";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+1";
+    public string[] CallingCode { get; } = ["+1"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/CapeVerde.cs
+++ b/src/World.Net/Countries/CapeVerde.cs
@@ -27,7 +27,7 @@ internal sealed class CapeVerde : ICountry
     public string ISO3Code { get; } = "CPV";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+238";
+    public string[] CallingCode { get; } = ["+238"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/CaymanIslands.cs
+++ b/src/World.Net/Countries/CaymanIslands.cs
@@ -18,7 +18,7 @@ internal sealed class CaymanIslands : ICountry
 
     public string ISO3Code => "CYM";
 
-    public string CallingCode => "+1-345";
+    public string[] CallingCode => ["+1-345"];
 
     public IEnumerable<State> States =>
     [

--- a/src/World.Net/Countries/CentralAfricanRepublic.cs
+++ b/src/World.Net/Countries/CentralAfricanRepublic.cs
@@ -18,7 +18,7 @@ internal sealed class CentralAfricanRepublic : ICountry
 
     public string ISO3Code => "CAF";
 
-    public string CallingCode => "+236";
+    public string[] CallingCode => ["+236"];
 
     public IEnumerable<State> States =>
     [

--- a/src/World.Net/Countries/Chad.cs
+++ b/src/World.Net/Countries/Chad.cs
@@ -18,7 +18,7 @@ internal sealed class Chad : ICountry
 
     public string ISO3Code => "TCD";
 
-    public string CallingCode => "+235";
+    public string[] CallingCode => ["+235"];
 
     public IEnumerable<State> States =>
     [

--- a/src/World.Net/Countries/Chile.cs
+++ b/src/World.Net/Countries/Chile.cs
@@ -22,7 +22,7 @@ internal sealed class Chile : ICountry
 
     public string ISO3Code => "CHL";
 
-    public string CallingCode => "+56";
+    public string[] CallingCode => ["+56"];
 
     public IEnumerable<State> States =>
     [

--- a/src/World.Net/Countries/China.cs
+++ b/src/World.Net/Countries/China.cs
@@ -18,7 +18,7 @@ internal sealed class China : ICountry
 
     public string ISO3Code => "CHN";
 
-    public string CallingCode => "+86";
+    public string[] CallingCode => ["+86"];
 
     public IEnumerable<State> States =>
     [

--- a/src/World.Net/Countries/ChristmasIsland.cs
+++ b/src/World.Net/Countries/ChristmasIsland.cs
@@ -27,7 +27,7 @@ internal sealed class ChristmasIsland : ICountry
     public string ISO3Code { get; } = "CXR";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+61";
+    public string[] CallingCode { get; } = ["+61"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/CocosKeelingIslands.cs
+++ b/src/World.Net/Countries/CocosKeelingIslands.cs
@@ -27,7 +27,7 @@ internal sealed class CocosKeelingIslands : ICountry
     public string ISO3Code { get; } = "CCK";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+61";
+    public string[] CallingCode { get; } = ["+61"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Colombia.cs
+++ b/src/World.Net/Countries/Colombia.cs
@@ -27,7 +27,7 @@ internal sealed class Colombia : ICountry
     public string ISO3Code { get; } = "COL";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+57";
+    public string[] CallingCode { get; } = ["+57"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Comoros.cs
+++ b/src/World.Net/Countries/Comoros.cs
@@ -27,7 +27,7 @@ internal sealed class Comoros : ICountry
     public string ISO3Code { get; } = "COM";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+269";
+    public string[] CallingCode { get; } = ["+269"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Congo.cs
+++ b/src/World.Net/Countries/Congo.cs
@@ -27,7 +27,7 @@
         public string ISO3Code { get; } = "COG";
 
         ///<inheritdoc/>
-        public string CallingCode { get; } = "+242";
+        public string[] CallingCode { get; } = ["+242"];
 
         ///<inheritdoc/>
         public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/CookIslands.cs
+++ b/src/World.Net/Countries/CookIslands.cs
@@ -27,7 +27,7 @@
         public string ISO3Code { get; } = "COK";
 
         ///<inheritdoc/>
-        public string CallingCode { get; } = "+682";
+        public string[] CallingCode { get; } = ["+682"];
 
         ///<inheritdoc/>
         public IEnumerable<State> States { get; } = [];

--- a/src/World.Net/Countries/CostaRica.cs
+++ b/src/World.Net/Countries/CostaRica.cs
@@ -27,7 +27,7 @@
         public string ISO3Code { get; } = "CRI";
 
         ///<inheritdoc/>
-        public string CallingCode { get; } = "+506";
+        public string[] CallingCode { get; } = ["+506"];
 
         ///<inheritdoc/>
         public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/CoteD'Ivoire.cs
+++ b/src/World.Net/Countries/CoteD'Ivoire.cs
@@ -27,7 +27,7 @@
         public string ISO3Code { get; } = "CIV";
 
         ///<inheritdoc/>
-        public string CallingCode { get; } = "+225";
+        public string[] CallingCode { get; } = ["+225"];
 
         ///<inheritdoc/>
         public IEnumerable<State> States { get; } =

--- a/src/World.Net/Countries/Croatia.cs
+++ b/src/World.Net/Countries/Croatia.cs
@@ -27,7 +27,7 @@ internal sealed class Croatia : ICountry
     public string ISO3Code { get; } = "HRV";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+385";
+    public string[] CallingCode { get; } = ["+385"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Cuba.cs
+++ b/src/World.Net/Countries/Cuba.cs
@@ -27,7 +27,7 @@ internal sealed class Cuba : ICountry
     public string ISO3Code { get; } = "CUB";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+53";
+    public string[] CallingCode { get; } = ["+53"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Curaçao.cs
+++ b/src/World.Net/Countries/Curaçao.cs
@@ -27,7 +27,7 @@ internal sealed class Curaçao : ICountry
     public string ISO3Code { get; } = "CUW";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+599";
+    public string[] CallingCode { get; } = ["+599"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/Cyprus.cs
+++ b/src/World.Net/Countries/Cyprus.cs
@@ -27,7 +27,7 @@ internal sealed class Cyprus : ICountry
     public string ISO3Code { get; } = "CYP";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+357";
+    public string[] CallingCode { get; } = ["+357"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/CzechRepublic.cs
+++ b/src/World.Net/Countries/CzechRepublic.cs
@@ -27,7 +27,7 @@ internal sealed class CzechRepublic : ICountry
     public string ISO3Code { get; } = "CZE";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+420";
+    public string[] CallingCode { get; } = ["+420"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/Countries/TheBahamas.cs
+++ b/src/World.Net/Countries/TheBahamas.cs
@@ -27,7 +27,7 @@ internal sealed class TheBahamas : ICountry
     public string ISO3Code { get; } = "BHS";
 
     //<inheritdoc/>
-    public string CallingCode { get; } = "+1 242";
+    public string[] CallingCode { get; } = ["+1 242"];
 
     //<inheritdoc/>
     public IEnumerable<State> States =>

--- a/src/World.Net/ICountry.cs
+++ b/src/World.Net/ICountry.cs
@@ -51,7 +51,7 @@ public interface ICountry
     /// <summary>
     /// The international calling code for the country.
     /// </summary>
-    string CallingCode { get; }
+    string[] CallingCode { get; }
 
     /// <summary>
     /// Gets the collection of states or administrative regions within the country.


### PR DESCRIPTION
I updated the `CallingCode` property to an array of strings and fixed all the failing tests caused by the change.